### PR TITLE
Wrong Request.new implementation

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -7,7 +7,7 @@ class RequestsController < ApplicationController
 
   # GET /requests/new
   def new
-    @request = current_user.requests.build(request_params)
+    @request = current_user.requests.new
   end
 
   # GET /requests/1/edit


### PR DESCRIPTION
Fixed new request object initialization. request_params is not
applicable.
